### PR TITLE
Change to string payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 - 2020-11-09
+
+- Change the `payload` keyword argument to `Ckeditor::Webhook.construct_event` from a `Hash` to a `String`. We can parse the JSON Rather than requiring callers to do so.
+- Change the internals to avoid the `to_json` method. Rails' [ActiveSupport::Hash](https://github.com/rails/activesupport-json_encoder/blob/master/lib/active_support/json/encoding/active_support_encoder.rb) appears to extend `to_json` to encode certain characters in HTML. Since the encoded payload does not equal the original payload, the signature verification fails.
+
 ## 0.2.1 - 2020-10-31
 
 - Remove "?" character from `path` if the URL's query string does not exist. This should fix signature verification errors for URLs without a query string.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ckeditor-webhook (0.2.0)
+    ckeditor-webhook (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ gem install ckeditor-webhook
 Call `Ckeditor::Webhook::construct_event` with the following keyword arguments to create a verified webhook event (if the webhook is invalid, a `Ckedior::Webhook::SignatureVerificationError` will be raised):
 
 - `secret` (`String`), the CKEditor Cloud Services [API secret](https://ckeditor.com/docs/cs/latest/guides/security/api-secret.html).
-- `payload` (`Hash`), the webhook's payload
+- `payload` (`String`), the webhook's payload
 - `signature` (`String`), the request's `X-CS-Signature` header
 - `timestamp` (`Integer`), the request's `X-CS-Timestamp` header
 - `url` (`String`), the request's url
@@ -41,8 +41,8 @@ For example:
 # Store your CKEditor Cloud Services API key safely.
 secret = "SECRET"
 
-payload = JSON.parse(request.body.read, symbolize_names: true)
-# => { event: "foo", environment_id: "bar", payload: { baz: "qux" }, sent_at: Time.now.utc }
+payload = request.body.read
+# => '{ "event": "foo", "environment_id": "bar", "payload": { baz: "qux" }, "sent_at": Time.now.utc }
 
 url = request.original_url
 # => "http://demo.example.com/webhook?a=1"

--- a/lib/ckeditor/webhook.rb
+++ b/lib/ckeditor/webhook.rb
@@ -15,7 +15,7 @@ module Ckeditor
       # Returns an Event if the webhook signature is valid.
       #
       # @param  secret     [String]   the CKEditor Cloud Services API secret
-      # @param  payload    [Hash]     the webhook's payload as a hash
+      # @param  payload    [String]   the webhook's string payload
       # @param  signature  [String]   the request's `X-CS-Signature` header
       # @param  timestamp  [Integer]  the request's `X-CS-Timestamp` header
       # @param  method     [String]   the request's method (defaults to "POST")
@@ -30,7 +30,7 @@ module Ckeditor
 
         raise SignatureVerificationError if signature != message_signature(message: event, secret: secret)
 
-        Event.new(payload)
+        Event.new(parse_payload(payload))
       end
 
       private
@@ -42,7 +42,7 @@ module Ckeditor
         uri    = URI.parse(url)
         path   = uri.path + (uri.query.nil? ? "" : "?#{uri.query}" )
         method = method.upcase
-        body   = payload.to_json
+        body   = sanitize_payload(payload)
 
         "#{method}#{path}#{timestamp}#{body}"
       end
@@ -53,6 +53,31 @@ module Ckeditor
           secret,
           message
         )
+      end
+
+      # Returns the string payload as a Hash with symbol keys.
+      #
+      # @return  [Hash]
+      # @raise   JSON::ParserError  if JSON is invalid
+      def parse_payload(payload)
+        JSON.parse(payload, symbolize_names: true)
+      end
+
+      # Returns the string payload... as a string.
+      #
+      #   1. I remove any whitespace. The signature is generated from JSON
+      #      without whitespace (e.g., '{"a":"ba"}'). Any unexpected spaces
+      #      (e.g., '{ "a": "b" }') will cause a signature verification failure.
+      #
+      #   2. I avoid the `to_json` method. Rails ActiveSupport extends the
+      #      method to encode HTML entities. For example, the "<" character is
+      #      encoded to "\u003c"). The encoded payload does not match the
+      #      original payload and will cause a signature verification failure.
+      #
+      # @return  [String]
+      # @raise   JSON::ParserError  if JSON is invalid
+      def sanitize_payload(payload)
+        JSON.generate(JSON.parse(payload))
       end
     end
   end

--- a/lib/ckeditor/webhook/version.rb
+++ b/lib/ckeditor/webhook/version.rb
@@ -1,5 +1,5 @@
 module Ckeditor
   module Webhook
-    VERSION = "0.2.1"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/ckeditor/webhook_spec.rb
+++ b/spec/ckeditor/webhook_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Ckeditor::Webhook do
     let(:method)    { "POST" }
     let(:url)       { "http://demo.example.com/webhook?a=1" }
     let(:timestamp) { 1563276169752 }
-    let(:payload)   { { a: 1 } }
+    let(:payload)   { '{ "a": 1 }' }
 
     context "when signatures do not match" do
       let(:signature) { "WRONG" }
@@ -36,7 +36,9 @@ RSpec.describe Ckeditor::Webhook do
 
       it "returns event" do
         # Actually calling Event.new with payload will raise PayloadInvalid exception.
-        expect(Ckeditor::Webhook::Event).to receive(:new).with(payload)
+        expect(Ckeditor::Webhook::Event).to receive(:new).with(
+          JSON.parse(payload, symbolize_names: true)
+        )
 
         Ckeditor::Webhook.construct_event(
           url:       url,


### PR DESCRIPTION
Hmm, we're experiencing some issues with the gem in production. It appears that Rails is impacting Ruby's `to_json` method to encode certain characters in the webhook's payload like "<" and ">". This is causing the signature verification to fail for webhooks that contain those characters. 

1. Let's handle parsing the data within the library. This makes things slightly easier for callers. 
1. Let's try avoiding the `to_json` method and using `JSON.generate` instead.